### PR TITLE
fix error/warning static inline delay() function

### DIFF
--- a/upgrade/utils.h
+++ b/upgrade/utils.h
@@ -68,7 +68,7 @@ typedef unsigned char boolean;
 #endif
 
 // delay in milliseconds - a custom implementation to avoid util/delay's tendancy to import floating point math libraries
-inline void delay(unsigned int ms) {
+static inline void delay(unsigned int ms) {
   while (ms > 0) {
     // delay for one millisecond (250*4 cycles, multiplied by cpu mhz)
     // subtract number of time taken in while loop and decrement and other bits


### PR DESCRIPTION
https://gist.github.com/Ircama/22707e938e9c8f169d9fe187797a2a2c
http://blog.zakkemble.co.uk/avr-gcc-builds/
Tool	Version
GCC	7.3.0
Binutils	2.30
AVR-LibC	2.0.0
AVRDUDE	6.3 (Not included in Linux release)
Make	4.2.1 (Not included in Linux release)

➜  upgrade avr-gcc -v
Using built-in specs.
Reading specs from c:/avr/avr-gcc-7.3.0-x64-mingw/bin/../lib/gcc/avr/7.3.0/device-specs/specs-avr2
COLLECT_GCC=C:\avr\avr-gcc-7.3.0-x64-mingw\bin\avr-gcc.exe
COLLECT_LTO_WRAPPER=c:/avr/avr-gcc-7.3.0-x64-mingw/bin/../libexec/gcc/avr/7.3.0/lto-wrapper.exe
Target: avr
Configured with: ../configure --prefix=/omgwtfbbq/win64 --target=avr --enable-languages=c,c++ --disable-nls --disable-libssp --disable-libada --with-dwarf2 --disable-shared --enable-static --host=x86_64-w64-mingw32 --build=x86_64-pc-linux-gnu
Thread model: single
gcc version 7.3.0 (GCC)
➜  upgrade avr-ld
C:\avr\avr-gcc-7.3.0-x64-mingw\bin\avr-ld.exe: no input files
➜  upgrade avr-ld -v
GNU ld (GNU Binutils) 2.30


➜  upgrade make
avr-gcc -Wall -Os -fno-move-loop-invariants -fno-tree-scev-cprop -fno-inline-small-functions -I. -Ilibs-device -mmcu=attiny85 -DF_CPU=16500000 -DAPP_ADDRESS=0x80  -c upgrade.c -o upgrade.o -Wa,-ahls=upgrade.c.lst
In file included from upgrade.c:21:0:
./utils.h:75:5: warning: '_delay_loop_2' is static but used in inline function 'delay' which is not static
     _delay_loop_2((25 * F_CPU / 100000));
     ^~~~~~~~~~~~~
avr-gcc -Wall -Os -fno-move-loop-invariants -fno-tree-scev-cprop -fno-inline-small-functions -I. -Ilibs-device -mmcu=attiny85 -DF_CPU=16500000 -DAPP_ADDRESS=0x80  -o upgrade.bin upgrade.o -Wl,--relax,--gc-sections -Wl,--section-start=.text=80,-Map=upgrade.map
upgrade.o: In function `beep':
upgrade.c:(.text+0x1f2): undefined reference to `delay'
upgrade.c:(.text+0x1fa): undefined reference to `delay'
upgrade.o: In function `main':
upgrade.c:(.text.startup+0xe): undefined reference to `delay'
upgrade.c:(.text.startup+0x18): undefined reference to `delay'
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile:191: upgrade.bin] Error 1

--------------------------
➜  upgrade make
avr-gcc -Wall -Os -fno-move-loop-invariants -fno-tree-scev-cprop -fno-inline-small-functions -I. -Ilibs-device -mmcu=attiny85 -DF_CPU=16500000 -DAPP_ADDRESS=0x80  -c upgrade.c -o upgrade.o -Wa,-ahls=upgrade.c.lst
avr-gcc -Wall -Os -fno-move-loop-invariants -fno-tree-scev-cprop -fno-inline-small-functions -I. -Ilibs-device -mmcu=attiny85 -DF_CPU=16500000 -DAPP_ADDRESS=0x80  -o upgrade.bin upgrade.o -Wl,--relax,--gc-sections -Wl,--section-start=.text=80,-Map=upgrade.map
rm -f upgrade.hex upgrade.eep.hex
avr-objcopy -j .text -j .data -O ihex upgrade.bin upgrade-app.hex
cat upgrade-prefix.hex upgrade-app.hex > upgrade.hex
rm upgrade-app.hex
avr-size upgrade.hex
   text    data     bss     dec     hex filename
      0    2146       0    2146     862 upgrade.hex